### PR TITLE
feat: add baseline application schema for foundational infrastructure

### DIFF
--- a/.changeset/baseline-schema-feature.md
+++ b/.changeset/baseline-schema-feature.md
@@ -1,0 +1,41 @@
+---
+"@codeiqlabs/aws-utils": minor
+---
+
+Add baseline application schema for foundational infrastructure
+
+This release introduces a new fourth application schema type for CodeIQLabs AWS projects:
+
+**New Features:**
+- **BaselineAppConfigSchema**: Complete foundational infrastructure configuration for workload accounts
+- **NetworkingConfigSchema**: Comprehensive VPC, subnet, routing, and gateway configurations
+- **SecurityConfigSchema**: Security groups, NACLs, IAM roles, KMS keys, and Session Manager setup
+- **ComplianceConfigSchema**: CloudTrail, Config, GuardDuty, Security Hub, Inspector, and Access Analyzer
+
+**Schema Architecture:**
+The CodeIQLabs configuration system now supports four application types:
+1. `management` - AWS Organizations, Identity Center, cross-account management
+2. `shared-services` - Centralized services (monitoring, Transit Gateway)
+3. `workload` - Application-specific infrastructure deployment
+4. `baseline` - Foundational infrastructure (VPC, security, compliance) ✨ **NEW**
+
+**Deployment Sequence:**
+```
+1. Management Account → ManagementAppConfigSchema
+2. Shared Services Account → SharedServicesAppConfigSchema  
+3. Workload Accounts → BaselineAppConfigSchema (first)
+4. Workload Accounts → WorkloadAppConfigSchema (second)
+```
+
+**Key Benefits:**
+- Consistent networking and security foundations across all workload accounts
+- Comprehensive compliance and monitoring setup out of the box
+- Type-safe configuration with full TypeScript support and IntelliSense
+- Modular design allows customization while maintaining standards
+
+**Breaking Changes:** None - this is a purely additive feature
+
+**JSON Schema Support:**
+- New `baseline-manifest.schema.json` for IntelliSense support
+- Updated `manifest.schema.json` to include baseline configuration type
+- All existing schemas remain unchanged and fully compatible

--- a/schemas/baseline-manifest.schema.json
+++ b/schemas/baseline-manifest.schema.json
@@ -1,0 +1,2193 @@
+{
+  "$ref": "#/definitions/BaselineAppConfig",
+  "definitions": {
+    "BaselineAppConfig": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string",
+          "minLength": 1,
+          "errorMessage": {
+            "minLength": "Project name cannot be empty"
+          }
+        },
+        "company": {
+          "type": "string",
+          "minLength": 1,
+          "errorMessage": {
+            "minLength": "Company name cannot be empty"
+          }
+        },
+        "type": {
+          "type": "string",
+          "const": "baseline"
+        },
+        "management": {
+          "type": "object",
+          "properties": {
+            "accountId": {
+              "type": "string",
+              "pattern": "^[0-9]{12}$",
+              "errorMessage": {
+                "pattern": "AWS Account ID must be exactly 12 digits"
+              }
+            },
+            "region": {
+              "type": "string",
+              "pattern": "^[a-z]{2}-[a-z]+-\\d+$",
+              "errorMessage": {
+                "pattern": "Invalid AWS region format (expected: us-east-1, eu-west-1, etc.)"
+              }
+            },
+            "environment": {
+              "type": "string",
+              "enum": ["nprd", "pprd", "prod", "mgmt", "shrd"]
+            }
+          },
+          "required": ["accountId", "region", "environment"],
+          "additionalProperties": false
+        },
+        "networking": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["create", "adopt"],
+              "default": "create"
+            },
+            "vpc": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                  "errorMessage": {
+                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                    "minLength": "Name cannot be empty"
+                  },
+                  "minLength": 1
+                },
+                "cidr": {
+                  "type": "string",
+                  "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[1-2][0-9]|3[0-2])$",
+                  "errorMessage": {
+                    "pattern": "Invalid CIDR block format (expected: 10.0.0.0/16)"
+                  }
+                },
+                "region": {
+                  "type": "string",
+                  "pattern": "^[a-z]{2}-[a-z]+-\\d+$",
+                  "errorMessage": {
+                    "pattern": "Invalid AWS region format (expected: us-east-1, eu-west-1, etc.)"
+                  }
+                },
+                "enableDnsHostnames": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "enableDnsSupport": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "subnets": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["public", "private", "isolated"]
+                      },
+                      "cidr": {
+                        "type": "string",
+                        "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[1-2][0-9]|3[0-2])$",
+                        "errorMessage": {
+                          "pattern": "Invalid CIDR block format (expected: 10.0.0.0/16)"
+                        }
+                      },
+                      "availabilityZone": {
+                        "type": "string",
+                        "pattern": "^[a-z]{2}-[a-z]+-\\d+[a-z]$",
+                        "errorMessage": {
+                          "pattern": "Invalid Availability Zone format (expected: us-east-1a)"
+                        }
+                      },
+                      "mapPublicIpOnLaunch": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": false
+                      },
+                      "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": ["name", "type", "cidr", "availabilityZone"],
+                    "additionalProperties": false
+                  },
+                  "minItems": 1,
+                  "errorMessage": {
+                    "minItems": "At least one subnet is required"
+                  }
+                },
+                "routeTables": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "routes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "destination": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "cidr"
+                                    },
+                                    "cidr": {
+                                      "type": "string",
+                                      "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[1-2][0-9]|3[0-2])$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid CIDR block format (expected: 10.0.0.0/16)"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "cidr"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "prefix-list"
+                                    },
+                                    "prefixListId": {
+                                      "type": "string",
+                                      "pattern": "^pl-[a-z0-9]+$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid prefix list ID"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type", "prefixListId"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "target": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "internet-gateway"
+                                    },
+                                    "gatewayId": {
+                                      "type": "string",
+                                      "pattern": "^igw-[a-z0-9]+$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid Internet Gateway ID"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "nat-gateway"
+                                    },
+                                    "gatewayId": {
+                                      "type": "string",
+                                      "pattern": "^nat-[a-z0-9]+$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid NAT Gateway ID"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "vpc-endpoint"
+                                    },
+                                    "endpointId": {
+                                      "type": "string",
+                                      "pattern": "^vpce-[a-z0-9]+$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid VPC Endpoint ID"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "transit-gateway"
+                                    },
+                                    "gatewayId": {
+                                      "type": "string",
+                                      "pattern": "^tgw-[a-z0-9]+$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid Transit Gateway ID"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "vpc-peering"
+                                    },
+                                    "connectionId": {
+                                      "type": "string",
+                                      "pattern": "^pcx-[a-z0-9]+$",
+                                      "errorMessage": {
+                                        "pattern": "Invalid VPC Peering Connection ID"
+                                      }
+                                    }
+                                  },
+                                  "required": ["type"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "description": {
+                              "type": "string",
+                              "minLength": 1,
+                              "errorMessage": {
+                                "minLength": "Description cannot be empty",
+                                "maxLength": "Description too long (max 500 characters)"
+                              },
+                              "maxLength": 500
+                            }
+                          },
+                          "required": ["destination", "target"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "subnetAssociations": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                          "errorMessage": {
+                            "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                            "minLength": "Name cannot be empty"
+                          },
+                          "minLength": 1
+                        }
+                      },
+                      "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                  }
+                },
+                "natGateways": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "subnetName": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "allocationId": {
+                        "type": "string",
+                        "pattern": "^eipalloc-[a-z0-9]+$",
+                        "errorMessage": {
+                          "pattern": "Invalid Allocation ID"
+                        }
+                      },
+                      "connectivityType": {
+                        "type": "string",
+                        "enum": ["public", "private"],
+                        "default": "public"
+                      },
+                      "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": ["name", "subnetName"],
+                    "additionalProperties": false
+                  }
+                },
+                "internetGateway": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "tags": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": ["name"],
+                  "additionalProperties": false
+                },
+                "vpcEndpoints": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "service": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "s3",
+                              "dynamodb",
+                              "ec2",
+                              "ssm",
+                              "ssmmessages",
+                              "ec2messages",
+                              "kms",
+                              "logs",
+                              "monitoring",
+                              "events",
+                              "secretsmanager",
+                              "lambda",
+                              "sts",
+                              "elasticloadbalancing"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": ["Gateway", "Interface"]
+                      },
+                      "subnetNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                          "errorMessage": {
+                            "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                            "minLength": "Name cannot be empty"
+                          },
+                          "minLength": 1
+                        }
+                      },
+                      "routeTableNames": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                          "errorMessage": {
+                            "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                            "minLength": "Name cannot be empty"
+                          },
+                          "minLength": 1
+                        }
+                      },
+                      "policyDocument": {
+                        "type": "object",
+                        "additionalProperties": {}
+                      },
+                      "privateDnsEnabled": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": true
+                      },
+                      "tags": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": ["name", "service", "type"],
+                    "additionalProperties": false
+                  }
+                },
+                "flowLogs": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "default": true
+                    },
+                    "destination": {
+                      "type": "string",
+                      "enum": ["cloudwatch", "s3"],
+                      "default": "cloudwatch"
+                    },
+                    "logFormat": {
+                      "type": "string"
+                    },
+                    "logGroup": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "s3Bucket": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "trafficType": {
+                      "type": "string",
+                      "enum": ["ALL", "ACCEPT", "REJECT"],
+                      "default": "ALL"
+                    },
+                    "tags": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": ["name", "cidr", "region", "subnets"],
+              "additionalProperties": false
+            }
+          },
+          "required": ["vpc"],
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["create", "adopt"],
+              "default": "create"
+            },
+            "securityGroups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                    "errorMessage": {
+                      "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                      "minLength": "Name cannot be empty"
+                    },
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "errorMessage": {
+                      "minLength": "Description cannot be empty",
+                      "maxLength": "Description too long (max 500 characters)"
+                    },
+                    "maxLength": 500
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": ["ingress", "egress"]
+                        },
+                        "protocol": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": ["tcp", "udp", "icmp", "icmpv6"]
+                            },
+                            {
+                              "type": "integer",
+                              "minimum": -1,
+                              "maximum": 255
+                            }
+                          ]
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 65535
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "from": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535
+                                },
+                                "to": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535
+                                }
+                              },
+                              "required": ["from", "to"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "source": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "cidr"
+                                },
+                                "cidr": {
+                                  "type": "string",
+                                  "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[1-2][0-9]|3[0-2])$",
+                                  "errorMessage": {
+                                    "pattern": "Invalid CIDR block format (expected: 10.0.0.0/16)"
+                                  }
+                                }
+                              },
+                              "required": ["type", "cidr"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "security-group"
+                                },
+                                "securityGroupId": {
+                                  "type": "string",
+                                  "pattern": "^sg-[a-z0-9]+$",
+                                  "errorMessage": {
+                                    "pattern": "Invalid Security Group ID"
+                                  }
+                                },
+                                "securityGroupName": {
+                                  "type": "string",
+                                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                                  "errorMessage": {
+                                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                                    "minLength": "Name cannot be empty"
+                                  },
+                                  "minLength": 1
+                                }
+                              },
+                              "required": ["type"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "const": "prefix-list"
+                                },
+                                "prefixListId": {
+                                  "type": "string",
+                                  "pattern": "^pl-[a-z0-9]+$",
+                                  "errorMessage": {
+                                    "pattern": "Invalid Prefix List ID"
+                                  }
+                                }
+                              },
+                              "required": ["type", "prefixListId"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "description": {
+                          "type": "string",
+                          "minLength": 1,
+                          "errorMessage": {
+                            "minLength": "Description cannot be empty",
+                            "maxLength": "Description too long (max 500 characters)"
+                          },
+                          "maxLength": 500
+                        }
+                      },
+                      "required": ["type", "protocol", "source"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["name", "description"],
+                "additionalProperties": false
+              }
+            },
+            "networkAcls": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                    "errorMessage": {
+                      "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                      "minLength": "Name cannot be empty"
+                    },
+                    "minLength": 1
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "ruleNumber": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 32766
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": ["ingress", "egress"]
+                        },
+                        "protocol": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": ["tcp", "udp", "icmp", "icmpv6"]
+                            },
+                            {
+                              "type": "integer",
+                              "minimum": -1,
+                              "maximum": 255
+                            }
+                          ]
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 65535
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "from": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535
+                                },
+                                "to": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 65535
+                                }
+                              },
+                              "required": ["from", "to"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "source": {
+                          "type": "string",
+                          "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[1-2][0-9]|3[0-2])$",
+                          "errorMessage": {
+                            "pattern": "Invalid CIDR block format (expected: 10.0.0.0/16)"
+                          }
+                        },
+                        "action": {
+                          "type": "string",
+                          "enum": ["allow", "deny"]
+                        },
+                        "description": {
+                          "type": "string",
+                          "minLength": 1,
+                          "errorMessage": {
+                            "minLength": "Description cannot be empty",
+                            "maxLength": "Description too long (max 500 characters)"
+                          },
+                          "maxLength": 500
+                        }
+                      },
+                      "required": ["ruleNumber", "type", "protocol", "source", "action"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "subnetAssociations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    }
+                  },
+                  "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            },
+            "iamRoles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                    "errorMessage": {
+                      "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                      "minLength": "Name cannot be empty"
+                    },
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "errorMessage": {
+                      "minLength": "Description cannot be empty",
+                      "maxLength": "Description too long (max 500 characters)"
+                    },
+                    "maxLength": 500
+                  },
+                  "assumeRolePolicy": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "string",
+                        "default": "2012-10-17"
+                      },
+                      "statements": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "effect": {
+                              "type": "string",
+                              "enum": ["Allow", "Deny"]
+                            },
+                            "actions": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "resources": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "conditions": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "principals": {
+                              "type": "object",
+                              "properties": {
+                                "AWS": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "Service": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "Federated": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["effect", "actions"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": ["statements"],
+                    "additionalProperties": false
+                  },
+                  "inlinePolicies": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "version": {
+                          "type": "string",
+                          "default": "2012-10-17"
+                        },
+                        "statements": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "effect": {
+                                "type": "string",
+                                "enum": ["Allow", "Deny"]
+                              },
+                              "actions": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
+                              },
+                              "resources": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
+                              },
+                              "conditions": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "principals": {
+                                "type": "object",
+                                "properties": {
+                                  "AWS": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "Service": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "Federated": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": ["effect", "actions"],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": ["statements"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "managedPolicyArns": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "maxSessionDuration": {
+                    "type": "integer",
+                    "minimum": 3600,
+                    "maximum": 43200
+                  },
+                  "path": {
+                    "type": "string",
+                    "default": "/"
+                  },
+                  "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["name", "assumeRolePolicy"],
+                "additionalProperties": false
+              }
+            },
+            "kmsKeys": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                    "errorMessage": {
+                      "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                      "minLength": "Name cannot be empty"
+                    },
+                    "minLength": 1
+                  },
+                  "description": {
+                    "type": "string",
+                    "minLength": 1,
+                    "errorMessage": {
+                      "minLength": "Description cannot be empty",
+                      "maxLength": "Description too long (max 500 characters)"
+                    },
+                    "maxLength": 500
+                  },
+                  "keyUsage": {
+                    "type": "string",
+                    "enum": ["ENCRYPT_DECRYPT", "SIGN_VERIFY"],
+                    "default": "ENCRYPT_DECRYPT"
+                  },
+                  "keySpec": {
+                    "type": "string",
+                    "enum": [
+                      "SYMMETRIC_DEFAULT",
+                      "RSA_2048",
+                      "RSA_3072",
+                      "RSA_4096",
+                      "ECC_NIST_P256",
+                      "ECC_NIST_P384",
+                      "ECC_NIST_P521",
+                      "ECC_SECG_P256K1"
+                    ],
+                    "default": "SYMMETRIC_DEFAULT"
+                  },
+                  "policy": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "string",
+                        "default": "2012-10-17"
+                      },
+                      "statements": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "effect": {
+                              "type": "string",
+                              "enum": ["Allow", "Deny"]
+                            },
+                            "actions": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "resources": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              ]
+                            },
+                            "conditions": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "principals": {
+                              "type": "object",
+                              "properties": {
+                                "AWS": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "Service": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "Federated": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": ["effect", "actions"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": ["statements"],
+                    "additionalProperties": false
+                  },
+                  "enableKeyRotation": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "default": true
+                  },
+                  "deletionWindowInDays": {
+                    "type": "integer",
+                    "minimum": 7,
+                    "maximum": 30
+                  },
+                  "aliases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tags": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["name", "description"],
+                "additionalProperties": false
+              }
+            },
+            "sessionManager": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "s3BucketName": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                  "errorMessage": {
+                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                    "minLength": "Name cannot be empty"
+                  },
+                  "minLength": 1
+                },
+                "s3KeyPrefix": {
+                  "type": "string"
+                },
+                "cloudWatchLogGroupName": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                  "errorMessage": {
+                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                    "minLength": "Name cannot be empty"
+                  },
+                  "minLength": 1
+                },
+                "cloudWatchEncryptionEnabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "idleSessionTimeout": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 60,
+                  "default": 20
+                },
+                "maxSessionDuration": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 60,
+                  "default": 60
+                },
+                "runAsEnabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": false
+                },
+                "runAsDefaultUser": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "compliance": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["create", "adopt"],
+              "default": "create"
+            },
+            "cloudTrail": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                  "errorMessage": {
+                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                    "minLength": "Name cannot be empty"
+                  },
+                  "minLength": 1
+                },
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "s3Config": {
+                  "type": "object",
+                  "properties": {
+                    "bucketName": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "keyPrefix": {
+                      "type": "string"
+                    },
+                    "includeGlobalServiceEvents": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "default": true
+                    },
+                    "isMultiRegionTrail": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "default": true
+                    },
+                    "enableLogFileValidation": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "default": true
+                    }
+                  },
+                  "required": ["bucketName"],
+                  "additionalProperties": false
+                },
+                "cloudWatchConfig": {
+                  "type": "object",
+                  "properties": {
+                    "logGroupName": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "roleArn": {
+                      "type": "string",
+                      "pattern": "^arn:aws:iam::\\d{12}:role\\/.*$",
+                      "errorMessage": {
+                        "pattern": "Invalid IAM role ARN"
+                      }
+                    }
+                  },
+                  "required": ["logGroupName"],
+                  "additionalProperties": false
+                },
+                "eventSelectors": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "readWriteType": {
+                        "type": "string",
+                        "enum": ["All", "ReadOnly", "WriteOnly"],
+                        "default": "All"
+                      },
+                      "includeManagementEvents": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": true
+                      },
+                      "dataResources": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "required": ["type", "values"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "excludeManagementEventSources": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "insightSelectors": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "insightType": {
+                        "type": "string",
+                        "enum": ["ApiCallRateInsight"]
+                      }
+                    },
+                    "required": ["insightType"],
+                    "additionalProperties": false
+                  }
+                },
+                "kmsKeyId": {
+                  "type": "string"
+                },
+                "snsTopicName": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                  "errorMessage": {
+                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                    "minLength": "Name cannot be empty"
+                  },
+                  "minLength": 1
+                },
+                "tags": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": ["name", "s3Config"],
+              "additionalProperties": false
+            },
+            "configService": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "recorder": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "roleArn": {
+                      "type": "string",
+                      "pattern": "^arn:aws:iam::\\d{12}:role\\/.*$",
+                      "errorMessage": {
+                        "pattern": "Invalid IAM role ARN"
+                      }
+                    },
+                    "recordingGroup": {
+                      "type": "object",
+                      "properties": {
+                        "allSupported": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "default": true
+                        },
+                        "includeGlobalResourceTypes": {
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "default": true
+                        },
+                        "resourceTypes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["name"],
+                  "additionalProperties": false
+                },
+                "deliveryChannel": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "s3BucketName": {
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                      "errorMessage": {
+                        "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                        "minLength": "Name cannot be empty"
+                      },
+                      "minLength": 1
+                    },
+                    "s3KeyPrefix": {
+                      "type": "string"
+                    },
+                    "snsTopicArn": {
+                      "type": "string",
+                      "pattern": "^arn:aws:sns:.*$",
+                      "errorMessage": {
+                        "pattern": "Invalid SNS topic ARN"
+                      }
+                    },
+                    "deliveryFrequency": {
+                      "type": "string",
+                      "enum": [
+                        "One_Hour",
+                        "Three_Hours",
+                        "Six_Hours",
+                        "Twelve_Hours",
+                        "TwentyFour_Hours"
+                      ],
+                      "default": "TwentyFour_Hours"
+                    }
+                  },
+                  "required": ["name", "s3BucketName"],
+                  "additionalProperties": false
+                },
+                "rules": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "description": {
+                        "type": "string",
+                        "minLength": 1,
+                        "errorMessage": {
+                          "minLength": "Description cannot be empty",
+                          "maxLength": "Description too long (max 500 characters)"
+                        },
+                        "maxLength": 500
+                      },
+                      "source": {
+                        "type": "object",
+                        "properties": {
+                          "owner": {
+                            "type": "string",
+                            "enum": ["AWS", "CUSTOM_LAMBDA"]
+                          },
+                          "sourceIdentifier": {
+                            "type": "string"
+                          },
+                          "sourceDetails": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "eventSource": {
+                                  "type": "string"
+                                },
+                                "messageType": {
+                                  "type": "string"
+                                },
+                                "maximumExecutionFrequency": {
+                                  "type": "string",
+                                  "enum": [
+                                    "One_Hour",
+                                    "Three_Hours",
+                                    "Six_Hours",
+                                    "Twelve_Hours",
+                                    "TwentyFour_Hours"
+                                  ]
+                                }
+                              },
+                              "required": ["eventSource", "messageType"],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": ["owner", "sourceIdentifier"],
+                        "additionalProperties": false
+                      },
+                      "inputParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "scope": {
+                        "type": "object",
+                        "properties": {
+                          "complianceResourceTypes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "tagKey": {
+                            "type": "string"
+                          },
+                          "tagValue": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": ["name", "source"],
+                    "additionalProperties": false
+                  }
+                },
+                "conformancePacks": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "templateS3Uri": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "templateBody": {
+                        "type": "string"
+                      },
+                      "deliveryS3Bucket": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "deliveryS3KeyPrefix": {
+                        "type": "string"
+                      },
+                      "inputParameters": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["recorder", "deliveryChannel"],
+              "additionalProperties": false
+            },
+            "guardDuty": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "findingPublishing": {
+                  "type": "object",
+                  "properties": {
+                    "frequency": {
+                      "type": "string",
+                      "enum": ["FIFTEEN_MINUTES", "ONE_HOUR", "SIX_HOURS"],
+                      "default": "SIX_HOURS"
+                    },
+                    "destinationArn": {
+                      "type": "string",
+                      "pattern": "^arn:aws:s3:::.*$",
+                      "errorMessage": {
+                        "pattern": "Invalid S3 bucket ARN"
+                      }
+                    },
+                    "kmsKeyArn": {
+                      "type": "string",
+                      "pattern": "^arn:aws:kms:.*$",
+                      "errorMessage": {
+                        "pattern": "Invalid KMS key ARN"
+                      }
+                    }
+                  },
+                  "required": ["destinationArn"],
+                  "additionalProperties": false
+                },
+                "malwareProtection": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "s3Protection": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "eksProtection": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "rdsProtection": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "lambdaProtection": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "invitationId": {
+                  "type": "string"
+                },
+                "masterId": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "securityHub": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "enableDefaultStandards": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "standards": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "arn": {
+                        "type": "string",
+                        "pattern": "^arn:aws:securityhub:.*$",
+                        "errorMessage": {
+                          "pattern": "Invalid Security Hub standard ARN"
+                        }
+                      },
+                      "enabled": {
+                        "anyOf": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "default": true
+                      }
+                    },
+                    "required": ["arn"],
+                    "additionalProperties": false
+                  }
+                },
+                "autoEnableControls": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "inspector": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "enableEc2": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "enableEcr": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "enableLambda": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "accessAnalyzer": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "default": true
+                },
+                "analyzerName": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                  "errorMessage": {
+                    "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                    "minLength": "Name cannot be empty"
+                  },
+                  "minLength": 1
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["ACCOUNT", "ORGANIZATION"],
+                  "default": "ACCOUNT"
+                },
+                "archiveRules": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "ruleName": {
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9\\s_-]+$",
+                        "errorMessage": {
+                          "pattern": "Name must contain only alphanumeric characters, spaces, hyphens, and underscores",
+                          "minLength": "Name cannot be empty"
+                        },
+                        "minLength": 1
+                      },
+                      "filter": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "required": ["ruleName", "filter"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": ["analyzerName"],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "createDefaultSecurityResources": {
+              "type": "boolean",
+              "default": true
+            },
+            "enableVpcFlowLogs": {
+              "type": "boolean",
+              "default": true
+            },
+            "createDefaultKmsKeys": {
+              "type": "boolean",
+              "default": true
+            },
+            "enableAllComplianceServices": {
+              "type": "boolean",
+              "default": true
+            },
+            "defaultTags": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "resourcePrefix": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["project", "company", "type", "management", "networking"],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BaselineAppConfig",
+  "description": "Schema for CodeIQLabs baseline account manifest files",
+  "$id": "https://raw.githubusercontent.com/CodeIQLabs/codeiqlabs-aws-utils/main/schemas/baseline-manifest.schema.json"
+}

--- a/schemas/manifest.schema.json
+++ b/schemas/manifest.schema.json
@@ -12,6 +12,14 @@
     {
       "$ref": "./workload-manifest.schema.json",
       "description": "Schema for CodeIQLabs workload account manifest files"
+    },
+    {
+      "$ref": "./shared-services-manifest.schema.json",
+      "description": "Schema for CodeIQLabs shared services account manifest files"
+    },
+    {
+      "$ref": "./baseline-manifest.schema.json",
+      "description": "Schema for CodeIQLabs baseline account manifest files"
     }
   ]
 }

--- a/schemas/shared-services-manifest.schema.json
+++ b/schemas/shared-services-manifest.schema.json
@@ -1,0 +1,79 @@
+{
+  "$ref": "#/definitions/SharedServicesAppConfig",
+  "definitions": {
+    "SharedServicesAppConfig": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string",
+          "minLength": 1,
+          "errorMessage": {
+            "minLength": "Project name cannot be empty"
+          }
+        },
+        "company": {
+          "type": "string",
+          "minLength": 1,
+          "errorMessage": {
+            "minLength": "Company name cannot be empty"
+          }
+        },
+        "type": {
+          "type": "string",
+          "const": "shared"
+        },
+        "sharedServices": {
+          "type": "object",
+          "properties": {
+            "services": {
+              "type": "object",
+              "properties": {
+                "monitoring": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "default": true
+                    },
+                    "centralLogging": {
+                      "type": "boolean",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "networking": {
+                  "type": "object",
+                  "properties": {
+                    "transitGateway": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "default": false
+                        },
+                        "asn": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["project", "company", "type", "sharedServices"],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SharedServicesAppConfig",
+  "description": "Schema for CodeIQLabs shared services account manifest files",
+  "$id": "https://raw.githubusercontent.com/CodeIQLabs/codeiqlabs-aws-utils/main/schemas/shared-services-manifest.schema.json"
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -43,12 +43,16 @@ export {
   IdentityCenterSchema,
   ManagementAppConfigSchema,
   WorkloadAppConfigSchema,
+  SharedServicesAppConfigSchema,
+  BaselineAppConfigSchema,
 } from './schemas';
 
 export {
   // Application schema aliases
   ManagementAppConfigSchema as ManagementApp,
   WorkloadAppConfigSchema as WorkloadApp,
+  SharedServicesAppConfigSchema as SharedServicesApp,
+  BaselineAppConfigSchema as BaselineApp,
 } from './schemas/applications';
 
 // Most commonly used types
@@ -64,4 +68,6 @@ export type {
   IdentityCenterConfig,
   ManagementAppConfig,
   WorkloadAppConfig,
+  SharedServicesAppConfig,
+  BaselineAppConfig,
 } from './schemas';

--- a/src/config/schemas/applications/baseline.ts
+++ b/src/config/schemas/applications/baseline.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import { ManifestBaseSchema } from '../base';
+import { ManagementConfigSchema } from '../resources/accounts';
+import { NetworkingConfigSchema } from '../resources/networking';
+import { SecurityConfigSchema } from '../resources/security';
+import { ComplianceConfigSchema } from '../resources/compliance';
+
+/**
+ * Baseline application configuration schema for CodeIQLabs AWS projects
+ *
+ * This schema defines the foundational infrastructure configuration that should be
+ * deployed to every workload account before application-specific infrastructure.
+ * It ensures consistent networking, security, and compliance foundations across
+ * all AWS accounts in the organization.
+ *
+ * The baseline configuration includes:
+ * - VPC and networking setup (subnets, routing, gateways)
+ * - Security configurations (security groups, NACLs, IAM roles, KMS)
+ * - Compliance and monitoring (CloudTrail, Config, GuardDuty, Security Hub)
+ * - Reference to management account for cross-account access
+ *
+ * This configuration should be deployed before any workload-specific infrastructure
+ * to provide a consistent foundation for all applications.
+ */
+
+/**
+ * Baseline application configuration schema
+ *
+ * Combines all foundational infrastructure components into a single
+ * configuration that can be deployed to establish account baselines.
+ */
+export const BaselineAppConfigSchema = ManifestBaseSchema.merge(
+  z.object({
+    /**
+     * Application type identifier
+     */
+    type: z.literal('baseline'),
+
+    /**
+     * Reference to management account configuration
+     * Used for cross-account role assumptions and organizational context
+     */
+    management: ManagementConfigSchema,
+
+    /**
+     * Networking configuration
+     * Defines VPC, subnets, routing, gateways, and network security
+     */
+    networking: NetworkingConfigSchema,
+
+    /**
+     * Security configuration
+     * Defines security groups, NACLs, IAM roles, KMS keys, and security policies
+     */
+    security: SecurityConfigSchema.optional(),
+
+    /**
+     * Compliance and monitoring configuration
+     * Defines CloudTrail, Config, GuardDuty, Security Hub, and other compliance tools
+     */
+    compliance: ComplianceConfigSchema.optional(),
+
+    /**
+     * Additional baseline configuration options
+     */
+    options: z
+      .object({
+        /**
+         * Whether to create default security groups and NACLs
+         */
+        createDefaultSecurityResources: z.boolean().default(true),
+
+        /**
+         * Whether to enable VPC Flow Logs by default
+         */
+        enableVpcFlowLogs: z.boolean().default(true),
+
+        /**
+         * Whether to create default KMS keys for encryption
+         */
+        createDefaultKmsKeys: z.boolean().default(true),
+
+        /**
+         * Whether to enable all compliance services by default
+         */
+        enableAllComplianceServices: z.boolean().default(true),
+
+        /**
+         * Default tags to apply to all baseline resources
+         */
+        defaultTags: z.record(z.string()).optional(),
+
+        /**
+         * Resource naming prefix for baseline resources
+         */
+        resourcePrefix: z.string().optional(),
+      })
+      .optional(),
+  }),
+);
+
+/**
+ * Type inference for the baseline application configuration
+ */
+export type BaselineAppConfig = z.infer<typeof BaselineAppConfigSchema>;
+
+/**
+ * Validation function for baseline application configuration
+ *
+ * @param config - The configuration object to validate
+ * @returns Validated and typed configuration object
+ * @throws ZodError if validation fails
+ */
+export function validateBaselineAppConfig(config: unknown): BaselineAppConfig {
+  return BaselineAppConfigSchema.parse(config);
+}
+
+/**
+ * Safe validation function for baseline application configuration
+ *
+ * @param config - The configuration object to validate
+ * @returns Success result with validated config or error result with validation issues
+ */
+export function safeValidateBaselineAppConfig(config: unknown) {
+  return BaselineAppConfigSchema.safeParse(config);
+}

--- a/src/config/schemas/applications/index.ts
+++ b/src/config/schemas/applications/index.ts
@@ -14,6 +14,9 @@ export * from './workload';
 // Re-export shared services application schemas
 export * from './shared-services';
 
+// Re-export baseline application schemas
+export * from './baseline';
+
 /**
  * Convenience re-exports for commonly used application schemas
  */
@@ -23,6 +26,8 @@ export { WorkloadAppConfigSchema } from './workload';
 
 export { SharedServicesAppConfigSchema } from './shared-services';
 
+export { BaselineAppConfigSchema } from './baseline';
+
 /**
  * Convenience re-exports for commonly used application types
  */
@@ -31,3 +36,5 @@ export type { ManagementAppConfig } from './management';
 export type { WorkloadAppConfig } from './workload';
 
 export type { SharedServicesAppConfig } from './shared-services';
+
+export type { BaselineAppConfig } from './baseline';

--- a/src/config/schemas/generate-json-schema.ts
+++ b/src/config/schemas/generate-json-schema.ts
@@ -2,7 +2,12 @@
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
-import { ManagementAppConfigSchema, WorkloadAppConfigSchema } from './applications/index';
+import {
+  ManagementAppConfigSchema,
+  WorkloadAppConfigSchema,
+  SharedServicesAppConfigSchema,
+  BaselineAppConfigSchema,
+} from './applications/index';
 
 interface SchemaDefinition {
   name: string;
@@ -30,6 +35,18 @@ export function generateJsonSchemas(): void {
       schema: WorkloadAppConfigSchema,
       filename: 'workload-manifest',
       description: 'Schema for CodeIQLabs workload account manifest files',
+    },
+    {
+      name: 'SharedServicesAppConfig',
+      schema: SharedServicesAppConfigSchema,
+      filename: 'shared-services-manifest',
+      description: 'Schema for CodeIQLabs shared services account manifest files',
+    },
+    {
+      name: 'BaselineAppConfig',
+      schema: BaselineAppConfigSchema,
+      filename: 'baseline-manifest',
+      description: 'Schema for CodeIQLabs baseline account manifest files',
     },
   ];
 

--- a/src/config/schemas/index.ts
+++ b/src/config/schemas/index.ts
@@ -44,28 +44,18 @@ export {
   // Account and management schemas
   AccountConfigSchema,
   ManagementConfigSchema,
-  PolicyDocumentSchema,
   ManagedPolicyArnSchema,
   ServicePrincipalSchema,
   ArnSchema,
-  S3BucketNameSchema,
-  StackNameSchema,
-  IamRoleNameSchema,
-  HostedZoneIdSchema,
-  DomainNameSchema,
-  AwsTagsSchema,
   // Organization schemas
   OrganizationalUnitSchema,
   OrganizationSchema,
   ServiceControlPolicySchema,
-  AccountCreationRequestSchema,
-  DelegatedAdministratorSchema,
   // Identity Center schemas
   PermissionSetConfigSchema,
   SSOAssignmentConfigSchema,
   IdentityCenterSchema,
   ApplicationConfigSchema,
-  AccountAssignmentRequestSchema,
   // IAM schemas
   CrossAccountRoleSchema,
   // GitHub OIDC schemas
@@ -75,12 +65,27 @@ export {
   // Project schemas
   ProjectEnvironmentSchema,
   ProjectSchema,
+  // Networking schemas
+  NetworkingConfigSchema,
+  VpcConfigSchema,
+  // Security schemas
+  SecurityConfigSchema,
+  SecurityGroupConfigSchema,
+  IamRoleConfigSchema,
+  KmsKeyConfigSchema,
+  // Compliance schemas
+  ComplianceConfigSchema,
+  CloudTrailConfigSchema,
+  ConfigServiceConfigSchema,
+  GuardDutyConfigSchema,
+  SecurityHubConfigSchema,
 } from './resources';
 
 export {
   ManagementAppConfigSchema,
   WorkloadAppConfigSchema,
   SharedServicesAppConfigSchema,
+  BaselineAppConfigSchema,
 } from './applications';
 
 /**
@@ -115,28 +120,18 @@ export type {
   // Account and management types
   AccountConfig,
   ManagementConfig,
-  PolicyDocument,
   ManagedPolicyArn,
   ServicePrincipal,
   Arn,
-  S3BucketName,
-  StackName,
-  IamRoleName,
-  HostedZoneId,
-  DomainName,
-  AwsTags,
   // Organization types
   OrganizationalUnitConfig,
   OrganizationConfig,
   ServiceControlPolicyConfig,
-  AccountCreationRequest,
-  DelegatedAdministrator,
   // Identity Center types
   PermissionSetConfig,
   SSOAssignmentConfig,
   IdentityCenterConfig,
   ApplicationConfig,
-  AccountAssignmentRequest,
   // IAM types
   CrossAccountRole,
   // GitHub OIDC types
@@ -146,6 +141,22 @@ export type {
   // Project types
   ProjectEnvironment,
   Project,
+  // Networking types
+  NetworkingConfig,
+  VpcConfig,
+  SubnetConfig,
+  SecurityGroupConfig,
+  // Security types
+  SecurityConfig,
+  IamRoleConfig,
+  KmsKeyConfig,
+  IamPolicyDocument,
+  // Compliance types
+  ComplianceConfig,
+  CloudTrailConfig,
+  ConfigServiceConfig,
+  GuardDutyConfig,
+  SecurityHubConfig,
 } from './resources';
 
 // Application types
@@ -153,4 +164,5 @@ export type {
   ManagementAppConfig,
   WorkloadAppConfig,
   SharedServicesAppConfig,
+  BaselineAppConfig,
 } from './applications';

--- a/src/config/schemas/resources/accounts.ts
+++ b/src/config/schemas/resources/accounts.ts
@@ -40,31 +40,6 @@ export const ManagementConfigSchema = z.object({
 });
 
 /**
- * AWS IAM policy document schema (simplified)
- */
-export const PolicyDocumentSchema = z.object({
-  Version: z.string().default('2012-10-17'),
-  Statement: z.array(
-    z.object({
-      Effect: z.enum(['Allow', 'Deny']),
-      Action: z.union([z.string(), z.array(z.string())]),
-      Resource: z.union([z.string(), z.array(z.string())]).optional(),
-      Principal: z
-        .union([
-          z.string(),
-          z.object({
-            AWS: z.union([z.string(), z.array(z.string())]).optional(),
-            Service: z.union([z.string(), z.array(z.string())]).optional(),
-            Federated: z.union([z.string(), z.array(z.string())]).optional(),
-          }),
-        ])
-        .optional(),
-      Condition: z.record(z.record(z.union([z.string(), z.array(z.string())]))).optional(),
-    }),
-  ),
-});
-
-/**
  * AWS managed policy ARN validation
  */
 export const ManagedPolicyArnSchema = z
@@ -94,89 +69,9 @@ export const ArnSchema = z
     'Invalid AWS ARN format',
   );
 
-/**
- * S3 bucket name validation
- */
-export const S3BucketNameSchema = z
-  .string()
-  .regex(/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/, 'Invalid S3 bucket name format')
-  .min(3, 'S3 bucket name must be at least 3 characters')
-  .max(63, 'S3 bucket name must be at most 63 characters');
-
-/**
- * CloudFormation stack name validation
- */
-export const StackNameSchema = z
-  .string()
-  .regex(
-    /^[a-zA-Z][a-zA-Z0-9-]*$/,
-    'Stack name must start with a letter and contain only alphanumeric characters and hyphens',
-  )
-  .min(1, 'Stack name cannot be empty')
-  .max(128, 'Stack name must be at most 128 characters');
-
-/**
- * IAM role name validation
- */
-export const IamRoleNameSchema = z
-  .string()
-  .regex(
-    /^[a-zA-Z0-9+=,.@_-]+$/,
-    'IAM role name can only contain alphanumeric characters and +=,.@_-',
-  )
-  .min(1, 'IAM role name cannot be empty')
-  .max(64, 'IAM role name must be at most 64 characters');
-
-/**
- * Route53 hosted zone ID validation
- */
-export const HostedZoneIdSchema = z
-  .string()
-  .regex(/^Z[A-Z0-9]+$/, 'Invalid Route53 hosted zone ID format');
-
-/**
- * Domain name validation
- */
-export const DomainNameSchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$/, 'Invalid domain name format')
-  .min(1, 'Domain name cannot be empty')
-  .max(253, 'Domain name must be at most 253 characters');
-
-/**
- * AWS resource tag key validation
- */
-export const TagKeySchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9\s_.:/=+@-]*$/, 'Invalid tag key format')
-  .min(1, 'Tag key cannot be empty')
-  .max(128, 'Tag key must be at most 128 characters');
-
-/**
- * AWS resource tag value validation
- */
-export const TagValueSchema = z
-  .string()
-  .regex(/^[a-zA-Z0-9\s_.:/=+@-]*$/, 'Invalid tag value format')
-  .max(256, 'Tag value must be at most 256 characters');
-
-/**
- * Enhanced tags schema with AWS-specific validation
- */
-export const AwsTagsSchema = z.record(TagKeySchema, TagValueSchema).optional();
-
 // Export types for TypeScript usage
 export type AccountConfig = z.infer<typeof AccountConfigSchema>;
 export type ManagementConfig = z.infer<typeof ManagementConfigSchema>;
-export type PolicyDocument = z.infer<typeof PolicyDocumentSchema>;
 export type ManagedPolicyArn = z.infer<typeof ManagedPolicyArnSchema>;
 export type ServicePrincipal = z.infer<typeof ServicePrincipalSchema>;
 export type Arn = z.infer<typeof ArnSchema>;
-export type S3BucketName = z.infer<typeof S3BucketNameSchema>;
-export type StackName = z.infer<typeof StackNameSchema>;
-export type IamRoleName = z.infer<typeof IamRoleNameSchema>;
-export type HostedZoneId = z.infer<typeof HostedZoneIdSchema>;
-export type DomainName = z.infer<typeof DomainNameSchema>;
-export type TagKey = z.infer<typeof TagKeySchema>;
-export type TagValue = z.infer<typeof TagValueSchema>;
-export type AwsTags = z.infer<typeof AwsTagsSchema>;

--- a/src/config/schemas/resources/compliance.ts
+++ b/src/config/schemas/resources/compliance.ts
@@ -1,0 +1,268 @@
+import { z } from 'zod';
+import {
+  BooleanSchema,
+  ConfigModeSchema,
+  NameSchema,
+  DescriptionSchema,
+  TagsSchema,
+} from '../base';
+
+/**
+ * Compliance configuration schemas for CodeIQLabs AWS projects
+ *
+ * This module provides validation schemas for AWS compliance and security services
+ * including CloudTrail, Config, GuardDuty, Security Hub, and other compliance tools.
+ */
+
+/**
+ * S3 bucket configuration for CloudTrail logs
+ */
+export const CloudTrailS3ConfigSchema = z.object({
+  bucketName: NameSchema,
+  keyPrefix: z.string().optional(),
+  includeGlobalServiceEvents: BooleanSchema.default(true),
+  isMultiRegionTrail: BooleanSchema.default(true),
+  enableLogFileValidation: BooleanSchema.default(true),
+});
+
+/**
+ * CloudWatch Logs configuration for CloudTrail
+ */
+export const CloudTrailCloudWatchConfigSchema = z.object({
+  logGroupName: NameSchema,
+  roleArn: z
+    .string()
+    .regex(/^arn:aws:iam::\d{12}:role\/.*$/, 'Invalid IAM role ARN')
+    .optional(),
+});
+
+/**
+ * CloudTrail event selector configuration
+ */
+export const CloudTrailEventSelectorSchema = z.object({
+  readWriteType: z.enum(['All', 'ReadOnly', 'WriteOnly']).default('All'),
+  includeManagementEvents: BooleanSchema.default(true),
+  dataResources: z
+    .array(
+      z.object({
+        type: z.string(), // e.g., "AWS::S3::Object"
+        values: z.array(z.string()), // e.g., ["arn:aws:s3:::bucket/*"]
+      }),
+    )
+    .optional(),
+  excludeManagementEventSources: z.array(z.string()).optional(),
+});
+
+/**
+ * CloudTrail insight selector configuration
+ */
+export const CloudTrailInsightSelectorSchema = z.object({
+  insightType: z.enum(['ApiCallRateInsight']),
+});
+
+/**
+ * CloudTrail configuration
+ */
+export const CloudTrailConfigSchema = z.object({
+  name: NameSchema,
+  enabled: BooleanSchema.default(true),
+  s3Config: CloudTrailS3ConfigSchema,
+  cloudWatchConfig: CloudTrailCloudWatchConfigSchema.optional(),
+  eventSelectors: z.array(CloudTrailEventSelectorSchema).optional(),
+  insightSelectors: z.array(CloudTrailInsightSelectorSchema).optional(),
+  kmsKeyId: z.string().optional(), // KMS key for encryption
+  snsTopicName: NameSchema.optional(),
+  tags: TagsSchema,
+});
+
+/**
+ * AWS Config delivery channel configuration
+ */
+export const ConfigDeliveryChannelSchema = z.object({
+  name: NameSchema,
+  s3BucketName: NameSchema,
+  s3KeyPrefix: z.string().optional(),
+  snsTopicArn: z
+    .string()
+    .regex(/^arn:aws:sns:.*$/, 'Invalid SNS topic ARN')
+    .optional(),
+  deliveryFrequency: z
+    .enum(['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours'])
+    .default('TwentyFour_Hours'),
+});
+
+/**
+ * AWS Config configuration recorder
+ */
+export const ConfigRecorderSchema = z.object({
+  name: NameSchema,
+  roleArn: z
+    .string()
+    .regex(/^arn:aws:iam::\d{12}:role\/.*$/, 'Invalid IAM role ARN')
+    .optional(),
+  recordingGroup: z
+    .object({
+      allSupported: BooleanSchema.default(true),
+      includeGlobalResourceTypes: BooleanSchema.default(true),
+      resourceTypes: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+/**
+ * AWS Config rule configuration
+ */
+export const ConfigRuleSchema = z.object({
+  name: NameSchema,
+  description: DescriptionSchema.optional(),
+  source: z.object({
+    owner: z.enum(['AWS', 'CUSTOM_LAMBDA']),
+    sourceIdentifier: z.string(), // AWS managed rule name or Lambda function ARN
+    sourceDetails: z
+      .array(
+        z.object({
+          eventSource: z.string(),
+          messageType: z.string(),
+          maximumExecutionFrequency: z
+            .enum(['One_Hour', 'Three_Hours', 'Six_Hours', 'Twelve_Hours', 'TwentyFour_Hours'])
+            .optional(),
+        }),
+      )
+      .optional(),
+  }),
+  inputParameters: z.record(z.string()).optional(),
+  scope: z
+    .object({
+      complianceResourceTypes: z.array(z.string()).optional(),
+      tagKey: z.string().optional(),
+      tagValue: z.string().optional(),
+    })
+    .optional(),
+});
+
+/**
+ * AWS Config conformance pack configuration
+ */
+export const ConfigConformancePackSchema = z.object({
+  name: NameSchema,
+  templateS3Uri: z.string().url().optional(),
+  templateBody: z.string().optional(),
+  deliveryS3Bucket: NameSchema.optional(),
+  deliveryS3KeyPrefix: z.string().optional(),
+  inputParameters: z.record(z.string()).optional(),
+});
+
+/**
+ * AWS Config configuration
+ */
+export const ConfigServiceConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  recorder: ConfigRecorderSchema,
+  deliveryChannel: ConfigDeliveryChannelSchema,
+  rules: z.array(ConfigRuleSchema).optional(),
+  conformancePacks: z.array(ConfigConformancePackSchema).optional(),
+});
+
+/**
+ * GuardDuty finding publishing configuration
+ */
+export const GuardDutyFindingPublishingSchema = z.object({
+  frequency: z.enum(['FIFTEEN_MINUTES', 'ONE_HOUR', 'SIX_HOURS']).default('SIX_HOURS'),
+  destinationArn: z.string().regex(/^arn:aws:s3:::.*$/, 'Invalid S3 bucket ARN'),
+  kmsKeyArn: z
+    .string()
+    .regex(/^arn:aws:kms:.*$/, 'Invalid KMS key ARN')
+    .optional(),
+});
+
+/**
+ * GuardDuty configuration
+ */
+export const GuardDutyConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  findingPublishing: GuardDutyFindingPublishingSchema.optional(),
+  malwareProtection: BooleanSchema.default(true),
+  s3Protection: BooleanSchema.default(true),
+  eksProtection: BooleanSchema.default(true),
+  rdsProtection: BooleanSchema.default(true),
+  lambdaProtection: BooleanSchema.default(true),
+  invitationId: z.string().optional(), // For member accounts
+  masterId: z.string().optional(), // For member accounts
+});
+
+/**
+ * Security Hub standards subscription
+ */
+export const SecurityHubStandardSchema = z.object({
+  arn: z.string().regex(/^arn:aws:securityhub:.*$/, 'Invalid Security Hub standard ARN'),
+  enabled: BooleanSchema.default(true),
+});
+
+/**
+ * Security Hub configuration
+ */
+export const SecurityHubConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  enableDefaultStandards: BooleanSchema.default(true),
+  standards: z.array(SecurityHubStandardSchema).optional(),
+  autoEnableControls: BooleanSchema.default(true),
+});
+
+/**
+ * Inspector V2 configuration
+ */
+export const InspectorConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  enableEc2: BooleanSchema.default(true),
+  enableEcr: BooleanSchema.default(true),
+  enableLambda: BooleanSchema.default(true),
+});
+
+/**
+ * Access Analyzer configuration
+ */
+export const AccessAnalyzerConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  analyzerName: NameSchema,
+  type: z.enum(['ACCOUNT', 'ORGANIZATION']).default('ACCOUNT'),
+  archiveRules: z
+    .array(
+      z.object({
+        ruleName: NameSchema,
+        filter: z.record(z.array(z.string())),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * Complete compliance configuration schema
+ */
+export const ComplianceConfigSchema = z.object({
+  mode: ConfigModeSchema.default('create'),
+  cloudTrail: CloudTrailConfigSchema.optional(),
+  configService: ConfigServiceConfigSchema.optional(),
+  guardDuty: GuardDutyConfigSchema.optional(),
+  securityHub: SecurityHubConfigSchema.optional(),
+  inspector: InspectorConfigSchema.optional(),
+  accessAnalyzer: AccessAnalyzerConfigSchema.optional(),
+});
+
+// Export types for TypeScript usage
+export type CloudTrailS3Config = z.infer<typeof CloudTrailS3ConfigSchema>;
+export type CloudTrailCloudWatchConfig = z.infer<typeof CloudTrailCloudWatchConfigSchema>;
+export type CloudTrailEventSelector = z.infer<typeof CloudTrailEventSelectorSchema>;
+export type CloudTrailInsightSelector = z.infer<typeof CloudTrailInsightSelectorSchema>;
+export type CloudTrailConfig = z.infer<typeof CloudTrailConfigSchema>;
+export type ConfigDeliveryChannel = z.infer<typeof ConfigDeliveryChannelSchema>;
+export type ConfigRecorder = z.infer<typeof ConfigRecorderSchema>;
+export type ConfigRule = z.infer<typeof ConfigRuleSchema>;
+export type ConfigConformancePack = z.infer<typeof ConfigConformancePackSchema>;
+export type ConfigServiceConfig = z.infer<typeof ConfigServiceConfigSchema>;
+export type GuardDutyFindingPublishing = z.infer<typeof GuardDutyFindingPublishingSchema>;
+export type GuardDutyConfig = z.infer<typeof GuardDutyConfigSchema>;
+export type SecurityHubStandard = z.infer<typeof SecurityHubStandardSchema>;
+export type SecurityHubConfig = z.infer<typeof SecurityHubConfigSchema>;
+export type InspectorConfig = z.infer<typeof InspectorConfigSchema>;
+export type AccessAnalyzerConfig = z.infer<typeof AccessAnalyzerConfigSchema>;
+export type ComplianceConfig = z.infer<typeof ComplianceConfigSchema>;

--- a/src/config/schemas/resources/identity-center.ts
+++ b/src/config/schemas/resources/identity-center.ts
@@ -175,18 +175,6 @@ export const IdentityCenterSchema = z.object({
   tags: TagsSchema,
 });
 
-/**
- * Account assignment request schema
- */
-export const AccountAssignmentRequestSchema = z.object({
-  instanceArn: IdentityCenterInstanceArnSchema,
-  permissionSetArn: PermissionSetArnSchema,
-  principalType: z.enum(['USER', 'GROUP']),
-  principalId: PrincipalIdSchema,
-  targetType: z.literal('AWS_ACCOUNT'),
-  targetId: AwsAccountIdSchema,
-});
-
 // Export types for TypeScript usage
 export type IdentityCenterInstanceArn = z.infer<typeof IdentityCenterInstanceArnSchema>;
 export type PermissionSetArn = z.infer<typeof PermissionSetArnSchema>;
@@ -197,4 +185,3 @@ export type IdentitySource = z.infer<typeof IdentitySourceSchema>;
 export type ApplicationConfig = z.infer<typeof ApplicationConfigSchema>;
 export type TrustedTokenIssuer = z.infer<typeof TrustedTokenIssuerSchema>;
 export type IdentityCenterConfig = z.infer<typeof IdentityCenterSchema>;
-export type AccountAssignmentRequest = z.infer<typeof AccountAssignmentRequestSchema>;

--- a/src/config/schemas/resources/index.ts
+++ b/src/config/schemas/resources/index.ts
@@ -22,16 +22,9 @@ export {
   // Account and management schemas
   AccountConfigSchema,
   ManagementConfigSchema,
-  PolicyDocumentSchema,
   ManagedPolicyArnSchema,
   ServicePrincipalSchema,
   ArnSchema,
-  S3BucketNameSchema,
-  StackNameSchema,
-  IamRoleNameSchema,
-  HostedZoneIdSchema,
-  DomainNameSchema,
-  AwsTagsSchema,
 } from './accounts';
 
 export {
@@ -39,8 +32,6 @@ export {
   OrganizationalUnitSchema,
   OrganizationSchema,
   ServiceControlPolicySchema,
-  AccountCreationRequestSchema,
-  DelegatedAdministratorSchema,
 } from './organizations';
 
 export {
@@ -49,7 +40,6 @@ export {
   SSOAssignmentConfigSchema,
   IdentityCenterSchema,
   ApplicationConfigSchema,
-  AccountAssignmentRequestSchema,
 } from './identity-center';
 
 export {
@@ -73,6 +63,39 @@ export {
   ProjectSchema,
 } from './projects';
 
+export {
+  // Networking schemas
+  NetworkingConfigSchema,
+  VpcConfigSchema,
+  SubnetConfigSchema,
+  RouteTableConfigSchema,
+  NatGatewayConfigSchema,
+  InternetGatewayConfigSchema,
+  VpcEndpointConfigSchema,
+  VpcFlowLogsConfigSchema,
+} from './networking';
+
+export {
+  // Security schemas
+  SecurityConfigSchema,
+  SecurityGroupConfigSchema,
+  NetworkAclConfigSchema,
+  IamRoleConfigSchema,
+  KmsKeyConfigSchema,
+  SessionManagerConfigSchema,
+} from './security';
+
+export {
+  // Compliance schemas
+  ComplianceConfigSchema,
+  CloudTrailConfigSchema,
+  ConfigServiceConfigSchema,
+  GuardDutyConfigSchema,
+  SecurityHubConfigSchema,
+  InspectorConfigSchema,
+  AccessAnalyzerConfigSchema,
+} from './compliance';
+
 /**
  * Convenience re-exports for commonly used resource types
  */
@@ -80,16 +103,9 @@ export type {
   // Account and management types
   AccountConfig,
   ManagementConfig,
-  PolicyDocument,
   ManagedPolicyArn,
   ServicePrincipal,
   Arn,
-  S3BucketName,
-  StackName,
-  IamRoleName,
-  HostedZoneId,
-  DomainName,
-  AwsTags,
 } from './accounts';
 
 export type {
@@ -97,8 +113,6 @@ export type {
   OrganizationalUnitConfig,
   OrganizationConfig,
   ServiceControlPolicyConfig,
-  AccountCreationRequest,
-  DelegatedAdministrator,
 } from './organizations';
 
 export type {
@@ -107,7 +121,6 @@ export type {
   SSOAssignmentConfig,
   IdentityCenterConfig,
   ApplicationConfig,
-  AccountAssignmentRequest,
 } from './identity-center';
 
 export type {
@@ -130,3 +143,41 @@ export type {
   ProjectEnvironment,
   Project,
 } from './projects';
+
+export type {
+  // Networking types
+  NetworkingConfig,
+  VpcConfig,
+  SubnetConfig,
+  RouteTableConfig,
+  NatGatewayConfig,
+  InternetGatewayConfig,
+  VpcEndpointConfig,
+  VpcFlowLogsConfig,
+  CidrBlock,
+  AvailabilityZone,
+  SubnetType,
+} from './networking';
+
+export type {
+  // Security types
+  SecurityConfig,
+  SecurityGroupConfig,
+  NetworkAclConfig,
+  IamRoleConfig,
+  KmsKeyConfig,
+  SessionManagerConfig,
+  SecurityGroupRule,
+  IamPolicyDocument,
+} from './security';
+
+export type {
+  // Compliance types
+  ComplianceConfig,
+  CloudTrailConfig,
+  ConfigServiceConfig,
+  GuardDutyConfig,
+  SecurityHubConfig,
+  InspectorConfig,
+  AccessAnalyzerConfig,
+} from './compliance';

--- a/src/config/schemas/resources/networking.ts
+++ b/src/config/schemas/resources/networking.ts
@@ -1,0 +1,236 @@
+import { z } from 'zod';
+import {
+  BooleanSchema,
+  ConfigModeSchema,
+  NameSchema,
+  DescriptionSchema,
+  TagsSchema,
+  AwsRegionSchema,
+} from '../base';
+
+/**
+ * Networking configuration schemas for CodeIQLabs AWS projects
+ *
+ * This module provides validation schemas for AWS networking resources
+ * including VPCs, subnets, routing, gateways, and network security configurations.
+ */
+
+/**
+ * CIDR block validation for VPCs and subnets
+ */
+export const CidrBlockSchema = z
+  .string()
+  .regex(
+    /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\/(?:[0-9]|[1-2][0-9]|3[0-2])$/,
+    'Invalid CIDR block format (expected: 10.0.0.0/16)',
+  );
+
+/**
+ * Availability Zone validation
+ */
+export const AvailabilityZoneSchema = z
+  .string()
+  .regex(/^[a-z]{2}-[a-z]+-\d+[a-z]$/, 'Invalid Availability Zone format (expected: us-east-1a)');
+
+/**
+ * Subnet type enumeration
+ */
+export const SubnetTypeSchema = z.enum(['public', 'private', 'isolated']);
+
+/**
+ * Route destination types
+ */
+export const RouteDestinationSchema = z.union([
+  z.object({
+    type: z.literal('cidr'),
+    cidr: CidrBlockSchema,
+  }),
+  z.object({
+    type: z.literal('prefix-list'),
+    prefixListId: z.string().regex(/^pl-[a-z0-9]+$/, 'Invalid prefix list ID'),
+  }),
+]);
+
+/**
+ * Route target types
+ */
+export const RouteTargetSchema = z.union([
+  z.object({
+    type: z.literal('internet-gateway'),
+    gatewayId: z
+      .string()
+      .regex(/^igw-[a-z0-9]+$/, 'Invalid Internet Gateway ID')
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('nat-gateway'),
+    gatewayId: z
+      .string()
+      .regex(/^nat-[a-z0-9]+$/, 'Invalid NAT Gateway ID')
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('vpc-endpoint'),
+    endpointId: z
+      .string()
+      .regex(/^vpce-[a-z0-9]+$/, 'Invalid VPC Endpoint ID')
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('transit-gateway'),
+    gatewayId: z
+      .string()
+      .regex(/^tgw-[a-z0-9]+$/, 'Invalid Transit Gateway ID')
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('vpc-peering'),
+    connectionId: z
+      .string()
+      .regex(/^pcx-[a-z0-9]+$/, 'Invalid VPC Peering Connection ID')
+      .optional(),
+  }),
+]);
+
+/**
+ * Individual subnet configuration
+ */
+export const SubnetConfigSchema = z.object({
+  name: NameSchema,
+  type: SubnetTypeSchema,
+  cidr: CidrBlockSchema,
+  availabilityZone: AvailabilityZoneSchema,
+  mapPublicIpOnLaunch: BooleanSchema.optional().default(false),
+  tags: TagsSchema,
+});
+
+/**
+ * Route table route configuration
+ */
+export const RouteConfigSchema = z.object({
+  destination: RouteDestinationSchema,
+  target: RouteTargetSchema,
+  description: DescriptionSchema.optional(),
+});
+
+/**
+ * Route table configuration
+ */
+export const RouteTableConfigSchema = z.object({
+  name: NameSchema,
+  routes: z.array(RouteConfigSchema).optional(),
+  subnetAssociations: z.array(NameSchema).optional(), // References subnet names
+  tags: TagsSchema,
+});
+
+/**
+ * NAT Gateway configuration
+ */
+export const NatGatewayConfigSchema = z.object({
+  name: NameSchema,
+  subnetName: NameSchema, // Reference to public subnet
+  allocationId: z
+    .string()
+    .regex(/^eipalloc-[a-z0-9]+$/, 'Invalid Allocation ID')
+    .optional(),
+  connectivityType: z.enum(['public', 'private']).default('public'),
+  tags: TagsSchema,
+});
+
+/**
+ * Internet Gateway configuration
+ */
+export const InternetGatewayConfigSchema = z.object({
+  name: NameSchema,
+  tags: TagsSchema,
+});
+
+/**
+ * VPC Endpoint service names for common AWS services
+ */
+export const VpcEndpointServiceSchema = z.enum([
+  's3',
+  'dynamodb',
+  'ec2',
+  'ssm',
+  'ssmmessages',
+  'ec2messages',
+  'kms',
+  'logs',
+  'monitoring',
+  'events',
+  'secretsmanager',
+  'lambda',
+  'sts',
+  'elasticloadbalancing',
+]);
+
+/**
+ * VPC Endpoint configuration
+ */
+export const VpcEndpointConfigSchema = z.object({
+  name: NameSchema,
+  service: z.union([VpcEndpointServiceSchema, z.string()]), // Predefined or custom service
+  type: z.enum(['Gateway', 'Interface']),
+  subnetNames: z.array(NameSchema).optional(), // For Interface endpoints
+  routeTableNames: z.array(NameSchema).optional(), // For Gateway endpoints
+  policyDocument: z.record(z.any()).optional(), // IAM policy document
+  privateDnsEnabled: BooleanSchema.optional().default(true),
+  tags: TagsSchema,
+});
+
+/**
+ * VPC Flow Logs configuration
+ */
+export const VpcFlowLogsConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  destination: z.enum(['cloudwatch', 's3']).default('cloudwatch'),
+  logFormat: z.string().optional(),
+  logGroup: NameSchema.optional(), // For CloudWatch destination
+  s3Bucket: NameSchema.optional(), // For S3 destination
+  trafficType: z.enum(['ALL', 'ACCEPT', 'REJECT']).default('ALL'),
+  tags: TagsSchema,
+});
+
+/**
+ * Complete VPC configuration schema
+ */
+export const VpcConfigSchema = z.object({
+  name: NameSchema,
+  cidr: CidrBlockSchema,
+  region: AwsRegionSchema,
+  enableDnsHostnames: BooleanSchema.default(true),
+  enableDnsSupport: BooleanSchema.default(true),
+  subnets: z.array(SubnetConfigSchema).min(1, 'At least one subnet is required'),
+  routeTables: z.array(RouteTableConfigSchema).optional(),
+  natGateways: z.array(NatGatewayConfigSchema).optional(),
+  internetGateway: InternetGatewayConfigSchema.optional(),
+  vpcEndpoints: z.array(VpcEndpointConfigSchema).optional(),
+  flowLogs: VpcFlowLogsConfigSchema.optional(),
+  tags: TagsSchema,
+});
+
+/**
+ * Complete networking configuration schema
+ */
+export const NetworkingConfigSchema = z.object({
+  mode: ConfigModeSchema.default('create'),
+  vpc: VpcConfigSchema,
+});
+
+// Export types for TypeScript usage
+export type CidrBlock = z.infer<typeof CidrBlockSchema>;
+export type AvailabilityZone = z.infer<typeof AvailabilityZoneSchema>;
+export type SubnetType = z.infer<typeof SubnetTypeSchema>;
+export type RouteDestination = z.infer<typeof RouteDestinationSchema>;
+export type RouteTarget = z.infer<typeof RouteTargetSchema>;
+export type SubnetConfig = z.infer<typeof SubnetConfigSchema>;
+export type RouteConfig = z.infer<typeof RouteConfigSchema>;
+export type RouteTableConfig = z.infer<typeof RouteTableConfigSchema>;
+export type NatGatewayConfig = z.infer<typeof NatGatewayConfigSchema>;
+export type InternetGatewayConfig = z.infer<typeof InternetGatewayConfigSchema>;
+export type VpcEndpointService = z.infer<typeof VpcEndpointServiceSchema>;
+export type VpcEndpointConfig = z.infer<typeof VpcEndpointConfigSchema>;
+export type VpcFlowLogsConfig = z.infer<typeof VpcFlowLogsConfigSchema>;
+export type VpcConfig = z.infer<typeof VpcConfigSchema>;
+export type NetworkingConfig = z.infer<typeof NetworkingConfigSchema>;

--- a/src/config/schemas/resources/organizations.ts
+++ b/src/config/schemas/resources/organizations.ts
@@ -1,13 +1,6 @@
 import { z } from 'zod';
-import {
-  BooleanSchema,
-  ConfigModeSchema,
-  KeySchema,
-  NameSchema,
-  AwsAccountIdSchema,
-  EmailSchema,
-} from '../base';
-import { AccountConfigSchema, ServicePrincipalSchema } from './accounts';
+import { BooleanSchema, ConfigModeSchema, KeySchema, NameSchema } from '../base';
+import { AccountConfigSchema } from './accounts';
 
 /**
  * AWS Organizations-specific schema components for CodeIQLabs configuration files
@@ -99,43 +92,6 @@ export const OrganizationSchema = z.object({
   tags: z.record(z.string()).optional(),
 });
 
-/**
- * Account creation request schema
- */
-export const AccountCreationRequestSchema = z.object({
-  accountName: NameSchema,
-  email: EmailSchema,
-  roleName: z.string().optional().default('OrganizationAccountAccessRole'),
-  iamUserAccessToBilling: z.enum(['ALLOW', 'DENY']).optional().default('DENY'),
-  tags: z.record(z.string()).optional(),
-});
-
-/**
- * Account move request schema (for moving accounts between OUs)
- */
-export const AccountMoveRequestSchema = z.object({
-  accountId: AwsAccountIdSchema,
-  sourceParentId: z.string(), // Current parent OU ID or root ID
-  destinationParentId: z.string(), // Target OU ID or root ID
-});
-
-/**
- * Organization invitation schema
- */
-export const OrganizationInvitationSchema = z.object({
-  targetEmail: EmailSchema,
-  targetAccountId: AwsAccountIdSchema.optional(),
-  notes: z.string().optional(),
-});
-
-/**
- * Delegated administrator configuration
- */
-export const DelegatedAdministratorSchema = z.object({
-  accountId: AwsAccountIdSchema,
-  servicePrincipal: ServicePrincipalSchema,
-});
-
 // Export types for TypeScript usage
 export type OrganizationalUnitId = z.infer<typeof OrganizationalUnitIdSchema>;
 export type OrganizationRootId = z.infer<typeof OrganizationRootIdSchema>;
@@ -144,7 +100,3 @@ export type OrganizationalUnitConfig = z.infer<typeof OrganizationalUnitSchema>;
 export type ServiceControlPolicyConfig = z.infer<typeof ServiceControlPolicySchema>;
 export type FeatureSet = z.infer<typeof FeatureSetSchema>;
 export type OrganizationConfig = z.infer<typeof OrganizationSchema>;
-export type AccountCreationRequest = z.infer<typeof AccountCreationRequestSchema>;
-export type AccountMoveRequest = z.infer<typeof AccountMoveRequestSchema>;
-export type OrganizationInvitation = z.infer<typeof OrganizationInvitationSchema>;
-export type DelegatedAdministrator = z.infer<typeof DelegatedAdministratorSchema>;

--- a/src/config/schemas/resources/security.ts
+++ b/src/config/schemas/resources/security.ts
@@ -1,0 +1,217 @@
+import { z } from 'zod';
+import {
+  BooleanSchema,
+  ConfigModeSchema,
+  NameSchema,
+  DescriptionSchema,
+  TagsSchema,
+} from '../base';
+import { CidrBlockSchema } from './networking';
+
+/**
+ * Security configuration schemas for CodeIQLabs AWS projects
+ *
+ * This module provides validation schemas for AWS security resources
+ * including security groups, NACLs, IAM roles, KMS keys, and security configurations.
+ */
+
+/**
+ * Port range validation
+ */
+export const PortRangeSchema = z.union([
+  z.number().int().min(0).max(65535), // Single port
+  z.object({
+    from: z.number().int().min(0).max(65535),
+    to: z.number().int().min(0).max(65535),
+  }), // Port range
+]);
+
+/**
+ * Protocol validation for security group rules
+ */
+export const ProtocolSchema = z.union([
+  z.enum(['tcp', 'udp', 'icmp', 'icmpv6']),
+  z.number().int().min(-1).max(255), // Protocol number (-1 for all)
+]);
+
+/**
+ * Security group rule source/destination
+ */
+export const SecurityGroupSourceSchema = z.union([
+  z.object({
+    type: z.literal('cidr'),
+    cidr: CidrBlockSchema,
+  }),
+  z.object({
+    type: z.literal('security-group'),
+    securityGroupId: z
+      .string()
+      .regex(/^sg-[a-z0-9]+$/, 'Invalid Security Group ID')
+      .optional(),
+    securityGroupName: NameSchema.optional(),
+  }),
+  z.object({
+    type: z.literal('prefix-list'),
+    prefixListId: z.string().regex(/^pl-[a-z0-9]+$/, 'Invalid Prefix List ID'),
+  }),
+]);
+
+/**
+ * Security group rule configuration
+ */
+export const SecurityGroupRuleSchema = z.object({
+  type: z.enum(['ingress', 'egress']),
+  protocol: ProtocolSchema,
+  port: PortRangeSchema.optional(),
+  source: SecurityGroupSourceSchema,
+  description: DescriptionSchema.optional(),
+});
+
+/**
+ * Security group configuration
+ */
+export const SecurityGroupConfigSchema = z.object({
+  name: NameSchema,
+  description: DescriptionSchema,
+  rules: z.array(SecurityGroupRuleSchema).optional(),
+  tags: TagsSchema,
+});
+
+/**
+ * Network ACL rule configuration
+ */
+export const NetworkAclRuleSchema = z.object({
+  ruleNumber: z.number().int().min(1).max(32766),
+  type: z.enum(['ingress', 'egress']),
+  protocol: ProtocolSchema,
+  port: PortRangeSchema.optional(),
+  source: CidrBlockSchema,
+  action: z.enum(['allow', 'deny']),
+  description: DescriptionSchema.optional(),
+});
+
+/**
+ * Network ACL configuration
+ */
+export const NetworkAclConfigSchema = z.object({
+  name: NameSchema,
+  rules: z.array(NetworkAclRuleSchema).optional(),
+  subnetAssociations: z.array(NameSchema).optional(), // References subnet names
+  tags: TagsSchema,
+});
+
+/**
+ * IAM policy statement configuration
+ */
+export const IamPolicyStatementSchema = z.object({
+  effect: z.enum(['Allow', 'Deny']),
+  actions: z.union([z.string(), z.array(z.string())]),
+  resources: z.union([z.string(), z.array(z.string())]).optional(),
+  conditions: z.record(z.record(z.union([z.string(), z.array(z.string())]))).optional(),
+  principals: z
+    .object({
+      AWS: z.union([z.string(), z.array(z.string())]).optional(),
+      Service: z.union([z.string(), z.array(z.string())]).optional(),
+      Federated: z.union([z.string(), z.array(z.string())]).optional(),
+    })
+    .optional(),
+});
+
+/**
+ * IAM policy document configuration
+ */
+export const IamPolicyDocumentSchema = z.object({
+  version: z.string().default('2012-10-17'),
+  statements: z.array(IamPolicyStatementSchema),
+});
+
+/**
+ * IAM role configuration
+ */
+export const IamRoleConfigSchema = z.object({
+  name: NameSchema,
+  description: DescriptionSchema.optional(),
+  assumeRolePolicy: IamPolicyDocumentSchema,
+  inlinePolicies: z.record(IamPolicyDocumentSchema).optional(),
+  managedPolicyArns: z.array(z.string()).optional(),
+  maxSessionDuration: z.number().int().min(3600).max(43200).optional(), // 1-12 hours
+  path: z.string().default('/'),
+  tags: TagsSchema,
+});
+
+/**
+ * KMS key policy configuration
+ */
+export const KmsKeyPolicySchema = z.object({
+  version: z.string().default('2012-10-17'),
+  statements: z.array(IamPolicyStatementSchema),
+});
+
+/**
+ * KMS key configuration
+ */
+export const KmsKeyConfigSchema = z.object({
+  name: NameSchema,
+  description: DescriptionSchema,
+  keyUsage: z.enum(['ENCRYPT_DECRYPT', 'SIGN_VERIFY']).default('ENCRYPT_DECRYPT'),
+  keySpec: z
+    .enum([
+      'SYMMETRIC_DEFAULT',
+      'RSA_2048',
+      'RSA_3072',
+      'RSA_4096',
+      'ECC_NIST_P256',
+      'ECC_NIST_P384',
+      'ECC_NIST_P521',
+      'ECC_SECG_P256K1',
+    ])
+    .default('SYMMETRIC_DEFAULT'),
+  policy: KmsKeyPolicySchema.optional(),
+  enableKeyRotation: BooleanSchema.default(true),
+  deletionWindowInDays: z.number().int().min(7).max(30).optional(),
+  aliases: z.array(z.string()).optional(),
+  tags: TagsSchema,
+});
+
+/**
+ * Systems Manager Session Manager configuration
+ */
+export const SessionManagerConfigSchema = z.object({
+  enabled: BooleanSchema.default(true),
+  s3BucketName: NameSchema.optional(), // For session logging
+  s3KeyPrefix: z.string().optional(),
+  cloudWatchLogGroupName: NameSchema.optional(),
+  cloudWatchEncryptionEnabled: BooleanSchema.default(true),
+  idleSessionTimeout: z.number().int().min(1).max(60).default(20), // Minutes
+  maxSessionDuration: z.number().int().min(1).max(60).default(60), // Minutes
+  runAsEnabled: BooleanSchema.default(false),
+  runAsDefaultUser: z.string().optional(),
+});
+
+/**
+ * Complete security configuration schema
+ */
+export const SecurityConfigSchema = z.object({
+  mode: ConfigModeSchema.default('create'),
+  securityGroups: z.array(SecurityGroupConfigSchema).optional(),
+  networkAcls: z.array(NetworkAclConfigSchema).optional(),
+  iamRoles: z.array(IamRoleConfigSchema).optional(),
+  kmsKeys: z.array(KmsKeyConfigSchema).optional(),
+  sessionManager: SessionManagerConfigSchema.optional(),
+});
+
+// Export types for TypeScript usage
+export type PortRange = z.infer<typeof PortRangeSchema>;
+export type Protocol = z.infer<typeof ProtocolSchema>;
+export type SecurityGroupSource = z.infer<typeof SecurityGroupSourceSchema>;
+export type SecurityGroupRule = z.infer<typeof SecurityGroupRuleSchema>;
+export type SecurityGroupConfig = z.infer<typeof SecurityGroupConfigSchema>;
+export type NetworkAclRule = z.infer<typeof NetworkAclRuleSchema>;
+export type NetworkAclConfig = z.infer<typeof NetworkAclConfigSchema>;
+export type IamPolicyStatement = z.infer<typeof IamPolicyStatementSchema>;
+export type IamPolicyDocument = z.infer<typeof IamPolicyDocumentSchema>;
+export type IamRoleConfig = z.infer<typeof IamRoleConfigSchema>;
+export type KmsKeyPolicy = z.infer<typeof KmsKeyPolicySchema>;
+export type KmsKeyConfig = z.infer<typeof KmsKeyConfigSchema>;
+export type SessionManagerConfig = z.infer<typeof SessionManagerConfigSchema>;
+export type SecurityConfig = z.infer<typeof SecurityConfigSchema>;


### PR DESCRIPTION
- Add BaselineAppConfigSchema for workload account foundations
- Add NetworkingConfigSchema for VPC, subnets, routing, gateways
- Add SecurityConfigSchema for security groups, IAM roles, KMS keys
- Add ComplianceConfigSchema for CloudTrail, Config, GuardDuty, Security Hub
- Update all index files to export new schemas and types
- Generate baseline-manifest.schema.json for IntelliSense support
- Update manifest.schema.json to include baseline configuration type
- Clean up unused schema definitions from previous cleanup

This completes the four-schema architecture:
1. management - Organizations, Identity Center, cross-account management
2. shared-services - Centralized services (monitoring, Transit Gateway)
3. workload - Application-specific infrastructure deployment
4. baseline - Foundational infrastructure (VPC, security, compliance)

BREAKING CHANGE: None - this is a purely additive feature